### PR TITLE
Refactor of the Agents module

### DIFF
--- a/reinforced_lib/agents/base_agent.py
+++ b/reinforced_lib/agents/base_agent.py
@@ -1,33 +1,64 @@
-from typing import NamedTuple, Callable
+from abc import ABC, abstractmethod
+from typing import Any, Tuple
 
+import chex
 import gym.spaces
 
+from reinforced_lib.agents.agent_state import AgentState
 
-class BaseAgent(NamedTuple):
+
+class BaseAgent(ABC):
     """
-    Container for functions of the agent.
+    Container for functions of the agent, observation spaces, and action space.
+    """
 
-    Fields
-    ------
-    init : Callable
-        Creates and initializes state for the agent.
-    update : Callable
+    @staticmethod
+    def init() -> AgentState:
+        """
+        Creates and initializes instance of the agent.
+        """
+
+        pass
+
+    @staticmethod
+    def update(state: AgentState, *args, **kwargs) -> AgentState:
+        """
         Updates the state of the agent after performing some action and receiving a reward.
-    sample : Callable
+        """
+
+        pass
+
+    @staticmethod
+    def sample(state: AgentState, key: chex.PRNGKey, *args, **kwargs) -> Tuple[AgentState, Any]:
+        """
         Selects next action based on current agent state.
+        """
 
-    update_observation_space : gym.spaces.Space
-        Parameters required by the agents 'update' function in OpenAI Gym format.
-    sample_observation_space : gym.spaces.Space
-        Parameters required by the agents 'sample' function in OpenAI Gym format.
-    action_space : gym.spaces.Space
+        pass
+
+    @property
+    @abstractmethod
+    def update_observation_space(self) -> gym.spaces.Space:
+        """
+        Parameters required by the 'update' method in OpenAI Gym format.
+        """
+
+        pass
+
+    @property
+    @abstractmethod
+    def sample_observation_space(self) -> gym.spaces.Space:
+        """
+        Parameters required by the 'sample' method in OpenAI Gym format.
+        """
+
+        pass
+
+    @property
+    @abstractmethod
+    def action_space(self) -> gym.spaces.Space:
+        """
         Action returned by the agent in OpenAI Gym format.
-    """
+        """
 
-    init: Callable
-    update: Callable
-    sample: Callable
-
-    update_observation_space: gym.spaces.Space
-    sample_observation_space: gym.spaces.Space
-    action_space: gym.spaces.Space
+        pass

--- a/reinforced_lib/agents/thompson_sampling.py
+++ b/reinforced_lib/agents/thompson_sampling.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import Tuple
 
 import chex
@@ -17,9 +18,9 @@ class ThompsonSamplingState(AgentState):
     Fields
     ------
     alpha : chex.Array
-        Number of successes for each arm.
+        Number of successful tries for each arm.
     beta : chex.Array
-        Number of failures for each arm.
+        Number of failed tries for each arm.
     last_decay : chex.Array
         Time of the last decay for each arm.
     """
@@ -29,194 +30,205 @@ class ThompsonSamplingState(AgentState):
     last_decay: chex.Array
 
 
-def thompson_sampling(context: chex.Array, decay: chex.Scalar = 1.0) -> BaseAgent:
+def init(context: chex.Array) -> ThompsonSamplingState:
     """
-    Contextual Bernoulli Thompson Sampling agent with exponential smoothing.
+    Creates and initializes instance of the Thompson Sampling agent.
 
     Parameters
     ----------
     context : chex.Array
-        One-dimensional array of arms values.
+        One-dimensional array of features of each arm.
+
+    Returns
+    -------
+    out : ThompsonSamplingState
+        Initial state of the Thompson Sampling agent.
+    """
+
+    return ThompsonSamplingState(
+        alpha=jnp.zeros_like(context),
+        beta=jnp.zeros_like(context),
+        last_decay=jnp.zeros_like(context)
+    )
+
+
+def update(
+        state: ThompsonSamplingState,
+        action: jnp.int32,
+        n_successful: jnp.int32,
+        n_failed: jnp.int32,
+        time: chex.Scalar,
+        decay: chex.Scalar
+) -> ThompsonSamplingState:
+    """
+    Updates the state of the agent after performing some action and receiving a reward.
+
+    Parameters
+    ----------
+    state : ThompsonSamplingState
+        Current state of agent.
+    action : int
+        Previously selected action.
+    n_successful : int
+        Number of successful tries.
+    n_failed : int
+        Number of failed tries.
+    time : float
+        Current time.
     decay : float
         Smoothing factor (decay = 0.0 means no smoothing).
 
     Returns
     -------
-    out : BaseAgent
-        Container for functions of the Thompson Sampling agent.
+    out : ThompsonSamplingState
+        Updated agent state.
     """
 
-    def update_observation_space() -> gym.spaces.Dict:
-        """
-        Defines parameters required by the agents 'update' function.
-
-        Returns
-        -------
-        out: gym.spaces.Dict
-            Parameters in OpenAI Gym format.
-        """
-
-        return gym.spaces.Dict({
-            'a': gym.spaces.Discrete(len(context)),
-            'r': gym.spaces.Discrete(2),
-            'time': gym.spaces.Box(0.0, float('inf'), shape=(1,))
-        })
-
-    def sample_observation_space() -> gym.spaces.Dict:
-        """
-        Defines parameters required by the agents 'sample' function.
-
-        Returns
-        -------
-        out: gym.spaces.Dict
-            Parameters in OpenAI Gym format.
-        """
-
-        return gym.spaces.Dict({
-            'key': gym.spaces.Space(dtype=chex.PRNGKey),
-            'time': gym.spaces.Box(0.0, float('inf'), shape=(1,))
-        })
-
-    def action_space() -> gym.spaces.Tuple:
-        """
-        Defines action returned by the agent.
-
-        Returns
-        -------
-        out: gym.spaces.Space
-            Action in OpenAI Gym format.
-        """
-
-        return gym.spaces.Tuple((gym.spaces.Discrete(len(context)),))
-
-    def init() -> ThompsonSamplingState:
-        """
-        Creates and initializes state for the Thompson Sampling agent.
-
-        Returns
-        -------
-        out : ThompsonSamplingState
-            Initial state of the Thompson Sampling agent.
-        """
-
-        return ThompsonSamplingState(
-            alpha=jnp.zeros_like(context),
-            beta=jnp.zeros_like(context),
-            last_decay=jnp.zeros_like(context)
-        )
-
-    def update(state: ThompsonSamplingState, a: jnp.int32, r: jnp.int32,
-               time: chex.Scalar = 0.0) -> ThompsonSamplingState:
-        """
-        Updates the state of the agent after performing some action and receiving a reward.
-
-        Parameters
-        ----------
-        state : ThompsonSamplingState
-            Current state of agent.
-        a : int
-            Previously selected action.
-        r : int or bool
-            Binary reward received for the previous action (1 - success, 0 - failure).
-        time : float
-            Current time.
-
-        Returns
-        -------
-        out : ThompsonSamplingState
-            Updated agent state.
-        """
-
-        state = _decay_one(state, a, time)
-        state = ThompsonSamplingState(
-            alpha=state.alpha.at[a].add(r),
-            beta=state.beta.at[a].add(1 - r),
-            last_decay=state.last_decay
-        )
-        return state
-
-    def sample(state: ThompsonSamplingState, key: chex.PRNGKey,
-               time: chex.Scalar = 0.0) -> Tuple[ThompsonSamplingState, jnp.int32]:
-        """
-        Selects next action based on current agent state.
-
-        Parameters
-        ----------
-        state : ThompsonSamplingState
-            Current state of the agent.
-        key : chex.PRNGKey
-            A PRNG key used as the random key.
-        time : float
-            Current time.
-
-        Returns
-        -------
-        out : Tuple[ThompsonSamplingState, int]
-            Tuple containing updated agent state and selected action.
-        """
-
-        state = _decay_all(state, time)
-        success_prob = jax.random.beta(key, 1 + state.alpha, 1 + state.beta)
-        action = jnp.argmax(success_prob * context)
-        return state, action
-
-    def _decay_one(state: ThompsonSamplingState, a: jnp.int32, time: chex.Scalar) -> ThompsonSamplingState:
-        """
-        Applies exponential smoothing for parameters related to action 'a'.
-
-        Parameters
-        ----------
-        state : ThompsonSamplingState
-            Current state of the agent.
-        a : int
-            Action to apply smoothing.
-        time : float
-            Current time.
-
-        Returns
-        -------
-        out : ThompsonSamplingState
-            Updated agent state.
-        """
-
-        smoothing_value = jnp.exp(decay * (state.last_decay[a] - time))
-        state = ThompsonSamplingState(
-            alpha=state.alpha.at[a].multiply(smoothing_value),
-            beta=state.beta.at[a].multiply(smoothing_value),
-            last_decay=state.last_decay.at[a].set(time)
-        )
-        return state
-
-    def _decay_all(state: ThompsonSamplingState, time: chex.Scalar) -> ThompsonSamplingState:
-        """
-        Applies exponential smoothing for all parameters.
-
-        Parameters
-        ----------
-        state : ThompsonSamplingState
-            Current state of the agent.
-        time : float
-            Current time.
-
-        Returns
-        -------
-        out : ThompsonSamplingState
-            Updated agent state.
-        """
-
-        smoothing_value = jnp.exp(decay * (state.last_decay - time))
-        state = ThompsonSamplingState(
-            alpha=state.alpha * smoothing_value,
-            beta=state.beta * smoothing_value,
-            last_decay=jnp.full_like(context, time)
-        )
-        return state
-
-    return BaseAgent(
-        init,
-        update,
-        sample,
-        update_observation_space,
-        sample_observation_space,
-        action_space
+    state = decay_one(state, action, time, decay)
+    state = ThompsonSamplingState(
+        alpha=state.alpha.at[action].add(n_successful),
+        beta=state.beta.at[action].add(n_failed),
+        last_decay=state.last_decay
     )
+    return state
+
+
+def sample(
+        state: ThompsonSamplingState,
+        key: chex.PRNGKey,
+        time: chex.Scalar,
+        context: chex.Array,
+        decay: chex.Scalar
+) -> Tuple[ThompsonSamplingState, jnp.int32]:
+    """
+    Selects next action based on current agent state.
+
+    Parameters
+    ----------
+    state : ThompsonSamplingState
+        Current state of the agent.
+    key : chex.PRNGKey
+        A PRNG key used as the random key.
+    time : float
+        Current time.
+    context : chex.Array
+        One-dimensional array of features of each arm.
+    decay : float
+        Smoothing factor (decay = 0.0 means no smoothing).
+
+    Returns
+    -------
+    out : Tuple[ThompsonSamplingState, int]
+        Tuple containing updated agent state and selected action.
+    """
+
+    state = decay_all(state, time, decay)
+    success_prob = jax.random.beta(key, 1 + state.alpha, 1 + state.beta)
+    action = jnp.argmax(success_prob * context)
+    return state, action
+
+
+def decay_one(
+        state: ThompsonSamplingState,
+        action: jnp.int32,
+        time: chex.Scalar,
+        decay: chex.Scalar
+) -> ThompsonSamplingState:
+    """
+    Applies exponential smoothing for parameters related to action 'a'.
+
+    Parameters
+    ----------
+    state : ThompsonSamplingState
+        Current state of the agent.
+    action : int
+        Action to apply smoothing.
+    time : float
+        Current time.
+    decay : float
+        Smoothing factor (decay = 0.0 means no smoothing).
+
+    Returns
+    -------
+    out : ThompsonSamplingState
+        Updated agent state.
+    """
+
+    smoothing_value = jnp.exp(decay * (state.last_decay[action] - time))
+    state = ThompsonSamplingState(
+        alpha=state.alpha.at[action].multiply(smoothing_value),
+        beta=state.beta.at[action].multiply(smoothing_value),
+        last_decay=state.last_decay.at[action].set(time)
+    )
+    return state
+
+
+def decay_all(
+        state: ThompsonSamplingState,
+        time: chex.Scalar,
+        decay: chex.Scalar
+) -> ThompsonSamplingState:
+    """
+    Applies exponential smoothing for all parameters.
+
+    Parameters
+    ----------
+    state : ThompsonSamplingState
+        Current state of the agent.
+    time : float
+        Current time.
+    decay : float
+        Smoothing factor (decay = 0.0 means no smoothing).
+
+    Returns
+    -------
+    out : ThompsonSamplingState
+        Updated agent state.
+    """
+
+    smoothing_value = jnp.exp(decay * (state.last_decay - time))
+    state = ThompsonSamplingState(
+        alpha=state.alpha * smoothing_value,
+        beta=state.beta * smoothing_value,
+        last_decay=jnp.full_like(state.last_decay, time)
+    )
+    return state
+
+
+class ThompsonSampling(BaseAgent):
+    def __init__(self, context: chex.Array, decay: chex.Scalar = 1.0):
+        """
+        Contextual Thompson Sampling agent with exponential smoothing.
+
+        Parameters
+        ----------
+        context : chex.Array
+            One-dimensional array of arms values.
+        decay : float
+            Smoothing factor (decay = 0.0 means no smoothing).
+        """
+
+        self.context_len = len(context)
+
+        self.init = jax.jit(partial(init, context=context))
+        self.update = jax.jit(partial(update, decay=decay))
+        self.sample = jax.jit(partial(sample, context=context, decay=decay))
+
+    @property
+    def update_observation_space(self) -> gym.spaces.Dict:
+        return gym.spaces.Dict({
+            'action': gym.spaces.Discrete(self.context_len),
+            'n_successful': gym.spaces.Box(0, jnp.inf, (1,), jnp.int32),
+            'n_failed': gym.spaces.Box(0, jnp.inf, (1,), jnp.int32),
+            'time': gym.spaces.Box(0.0, jnp.inf, (1,))
+        })
+
+    @property
+    def sample_observation_space(self) -> gym.spaces.Dict:
+        return gym.spaces.Dict({
+            'time': gym.spaces.Box(0.0, jnp.inf, (1,))
+        })
+
+    @property
+    def action_space(self) -> gym.spaces.Discrete:
+        return gym.spaces.Discrete(self.context_len)

--- a/reinforced_lib/agents/thompson_sampling.py
+++ b/reinforced_lib/agents/thompson_sampling.py
@@ -196,18 +196,18 @@ def decay_all(
 
 
 class ThompsonSampling(BaseAgent):
+    """
+    Contextual Thompson Sampling agent with exponential smoothing.
+
+    Parameters
+    ----------
+    context : chex.Array
+        One-dimensional array of arms values.
+    decay : float
+        Smoothing factor (decay = 0.0 means no smoothing).
+    """
+
     def __init__(self, context: chex.Array, decay: chex.Scalar = 1.0):
-        """
-        Contextual Thompson Sampling agent with exponential smoothing.
-
-        Parameters
-        ----------
-        context : chex.Array
-            One-dimensional array of arms values.
-        decay : float
-            Smoothing factor (decay = 0.0 means no smoothing).
-        """
-
         self.context_len = len(context)
 
         self.init = jax.jit(partial(init, context=context))

--- a/reinforced_lib/envs/base_env.py
+++ b/reinforced_lib/envs/base_env.py
@@ -9,23 +9,23 @@ from reinforced_lib.utils.exceptions import IncorrectSpaceError, IncompatibleSpa
 
 
 class BaseEnv(ABC):
+    """
+    Container for domain-specific knowledge and functions for a given environment. Provides transformation
+    from environment functions and observation space to agents observation and sample spaces.
+
+    Parameters
+    ----------
+    agent_update_space : gym.spaces.Space
+        Observations required by the agents 'update' function in OpenAI Gym format.
+    agent_sample_space : gym.spaces.Space
+        Observations required by the agents 'sample' function in OpenAI Gym format.
+    """
+
     def __init__(
             self,
             agent_update_space: gym.spaces.Space = None,
             agent_sample_space: gym.spaces.Space = None
     ) -> None:
-        """
-        Container for domain-specific knowledge and functions for a given environment. Provides transformation
-        from environment functions and observation space to agents observation and sample spaces.
-
-        Parameters
-        ----------
-        agent_update_space : gym.spaces.Space
-            Observations required by the agents 'update' function in OpenAI Gym format.
-        agent_sample_space : gym.spaces.Space
-            Observations required by the agents 'sample' function in OpenAI Gym format.
-        """
-
         self._observation_functions: Dict[str, Callable] = {}
 
         for name in dir(self):

--- a/reinforced_lib/envs/ieee_802_11_ax.py
+++ b/reinforced_lib/envs/ieee_802_11_ax.py
@@ -42,7 +42,8 @@ class IEEE_802_11_ax(BaseEnv):
         'n_failed': gym.spaces.Box(0, np.inf, (1,), np.int32),
         'n_wifi': gym.spaces.Box(1, np.inf, (1,), np.int32),
         'power': gym.spaces.Box(-np.inf, np.inf, (1,)),
-        'cw': gym.spaces.Discrete(32767)
+        'cw': gym.spaces.Discrete(32767),
+        'mcs': gym.spaces.Discrete(12)
     })
 
     _wifi_modes_rates = np.array([
@@ -94,3 +95,7 @@ class IEEE_802_11_ax(BaseEnv):
     @observation(observation_type=gym.spaces.Box(0.0, 1.0, (len(_wifi_modes_rates),)))
     def success_probability(self, snr: float, *args, **kwargs) -> np.ndarray:
         return 0.5 * (1 + erf(2 * (snr - self._wifi_modes_snrs + 0.5)))
+
+    @observation(observation_type=gym.spaces.Discrete(len(_wifi_modes_rates)))
+    def action(self, mcs: int, *args, **kwargs) -> int:
+        return mcs

--- a/reinforced_lib/envs/ieee_802_11_ax.py
+++ b/reinforced_lib/envs/ieee_802_11_ax.py
@@ -7,33 +7,33 @@ from reinforced_lib.envs.utils import observation
 
 
 class IEEE_802_11_ax(BaseEnv):
+    """
+    IEEE 802.11ax [1] environment. Provides data rates (in Mb/s) for consecutive MCS (modulation and coding scheme)
+    modes, minimal SNR (signal-to-noise ratio) for each MCS, approximated collision probability for a given number
+    of transmitting stations, and approximated transmission success probability for a given SNR and all MCS modes.
+
+    Parameters
+    ----------
+    agent_update_space : gym.spaces.Space
+        Parameters required by the agents 'update' function in OpenAI Gym format.
+    agent_sample_space : gym.spaces.Space
+        Parameters required by the agents 'sample' function in OpenAI Gym format.
+
+    References
+    ----------
+        [1] "IEEE Standard for Information Technology--Telecommunications and Information Exchange between Systems
+        Local and Metropolitan Area Networks--Specific Requirements Part 11: Wireless LAN Medium Access Control
+        (MAC) and Physical Layer (PHY) Specifications Amendment 1: Enhancements for High-Efficiency WLAN,"
+        in IEEE Std 802.11ax-2021 (Amendment to IEEE Std 802.11-2020) , vol., no., pp.1-767,
+        19 May 2021, doi: 10.1109/IEEESTD.2021.9442429.
+
+    """
+
     def __init__(
             self,
             agent_update_space: gym.spaces.Space = None,
             agent_sample_space: gym.spaces.Space = None
     ) -> None:
-        """
-        IEEE 802.11ax [1] environment. Provides data rates (in Mb/s) for consecutive MCS (modulation and coding scheme)
-        modes, minimal SNR (signal-to-noise ratio) for each MCS, approximated collision probability for a given number
-        of transmitting stations, and approximated transmission success probability for a given SNR and all MCS modes.
-
-        Parameters
-        ----------
-        agent_update_space : gym.spaces.Space
-            Parameters required by the agents 'update' function in OpenAI Gym format.
-        agent_sample_space : gym.spaces.Space
-            Parameters required by the agents 'sample' function in OpenAI Gym format.
-
-        References
-        ----------
-        .. [1] "IEEE Standard for Information Technology--Telecommunications and Information Exchange between Systems
-            Local and Metropolitan Area Networks--Specific Requirements Part 11: Wireless LAN Medium Access Control
-            (MAC) and Physical Layer (PHY) Specifications Amendment 1: Enhancements for High-Efficiency WLAN,"
-            in IEEE Std 802.11ax-2021 (Amendment to IEEE Std 802.11-2020) , vol., no., pp.1-767,
-            19 May 2021, doi: 10.1109/IEEESTD.2021.9442429.
-
-        """
-
         super().__init__(agent_update_space, agent_sample_space)
 
     observation_space = gym.spaces.Dict({

--- a/reinforced_lib/rlib.py
+++ b/reinforced_lib/rlib.py
@@ -8,6 +8,27 @@ from reinforced_lib.utils.exceptions import *
 
 
 class RLib:
+    """
+    Main class of the library. Exposes a simple and intuitive interface to use the library.
+
+    Parameters
+    ----------
+    agent_type : type
+        Type of selected agent. Must inherit from the BaseAgent class.
+    agent_params : Dict
+        Parameters of selected agent.
+    env_type : type
+        Type of selected environment. Must inherit from the BaseEnv class.
+    env_params : Dict
+        Parameters of selected environment.
+    log_type : Union[type, List[type]]
+        Types of selected logging modules.
+    log_params : Union[Dict, List[Dict]]
+        Parameters of selected logging modules.
+    no_env_mode : bool
+        Pass observations directly to agent (don't use envs module).
+    """
+
     def __init__(
             self, *,
             agent_type: type = None,
@@ -18,27 +39,6 @@ class RLib:
             log_params: Union[Dict, List[Dict]] = None,
             no_env_mode: bool = False
     ) -> None:
-        """
-        Main class of the library. Exposes a simple and intuitive interface to use the library.
-
-        Parameters
-        ----------
-        agent_type : type
-            Type of selected agent. Must inherit from the BaseAgent class.
-        agent_params : Dict
-            Parameters of selected agent.
-        env_type : type
-            Type of selected environment. Must inherit from the BaseEnv class.
-        env_params : Dict
-            Parameters of selected environment.
-        log_type : Union[type, List[type]]
-            Types of selected logging modules.
-        log_params : Union[Dict, List[Dict]]
-            Parameters of selected logging modules.
-        no_env_mode : bool
-            Pass observations directly to agent (don't use envs module).
-        """
-
         self._no_env_mode = no_env_mode
 
         self._agent = None
@@ -194,7 +194,7 @@ class RLib:
         """
 
         agent_id = len(self._agents_states)
-        seed = seed if seed else 0
+        seed = seed if seed else 42
 
         self._agents_states.append(self._agent.init())
         self._agents_keys.append(jax.random.PRNGKey(seed))


### PR DESCRIPTION
Zdecydowałem się zmienić architekturę agentów z funkcji zwracających `BaseAgent` do klas, które implementują `BaseAgent`. Po pierwsze dlatego, że ciężko było to zaprogramować tak, żeby agenci bez problemu działali z warstwą API, a po drugie dlatego, aby było spójnie - warstwa środowisk też jest klasami, które dziedziczą po BaseEnv. Nie tracimy zysków z jednokrotnej kompilacji w JAX, bo robię to tylko raz w konstruktorze klasy i używam domknięć.